### PR TITLE
fix(messages): sort correct chats by last message timestamp

### DIFF
--- a/PrismMessenger/Messages/Adapter/Persistence/ChatRepository.swift
+++ b/PrismMessenger/Messages/Adapter/Persistence/ChatRepository.swift
@@ -28,7 +28,8 @@ class SwiftDataChatRepository: ChatRepository {
         let descriptor = FetchDescriptor<Chat>(
             predicate: #Predicate<Chat> { chat in
                 chat.ownerUsername == username
-            }
+            },
+            sortBy: [SortDescriptor(\.lastMessageTimestamp, order: .reverse)]
         )
         
         return try modelContext.fetch(descriptor)
@@ -38,10 +39,8 @@ class SwiftDataChatRepository: ChatRepository {
         let descriptor = FetchDescriptor<Chat>(
             predicate: #Predicate<Chat> { chat in
                 chat.id == id
-            },
-            sortBy: [SortDescriptor(\.lastMessageTimestamp, order: .reverse)]
+            }
         )
-        
         let chats = try modelContext.fetch(descriptor)
         return chats.first
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chats are now displayed in order of most recent message when viewing all chats.
  - Retrieving a specific chat by ID no longer applies unnecessary sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->