### PR TITLE
build: separate bundle ID for development

### DIFF
--- a/PrismMessenger.xcodeproj/project.pbxproj
+++ b/PrismMessenger.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		DD0CC65C2D4B88E600DAC02D /* PrismMessenger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrismMessenger.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD0CC65C2D4B88E600DAC02D /* Prism Messenger Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Prism Messenger Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD0CC66C2D4B88E800DAC02D /* PrismMessengerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrismMessengerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD0CC6762D4B88E800DAC02D /* PrismMessengerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrismMessengerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD0CC76D2D54B96400DAC02D /* .gitignore */ = {isa = PBXFileReference; explicitFileType = text; path = .gitignore; sourceTree = "<group>"; };
@@ -133,7 +133,7 @@
 		DD0CC65D2D4B88E600DAC02D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DD0CC65C2D4B88E600DAC02D /* PrismMessenger.app */,
+				DD0CC65C2D4B88E600DAC02D /* Prism Messenger Dev.app */,
 				DD0CC66C2D4B88E800DAC02D /* PrismMessengerTests.xctest */,
 				DD0CC6762D4B88E800DAC02D /* PrismMessengerUITests.xctest */,
 				DD508DF52D8AB2F900293B79 /* PrismMessengerIntegrationTests.xctest */,
@@ -164,7 +164,7 @@
 				DD0CC7702D54E36400DAC02D /* KeychainAccess */,
 			);
 			productName = PrismMessenger;
-			productReference = DD0CC65C2D4B88E600DAC02D /* PrismMessenger.app */;
+			productReference = DD0CC65C2D4B88E600DAC02D /* Prism Messenger Dev.app */;
 			productType = "com.apple.product-type.application";
 		};
 		DD0CC66B2D4B88E800DAC02D /* PrismMessengerTests */ = {
@@ -371,7 +371,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		DD0CC67E2D4B88E800DAC02D /* Debug */ = {
+		DD0CC67E2D4B88E800DAC02D /* Development */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DD7E4A2A2DA5214D00A31DDD /* Development.xcconfig */;
 			buildSettings = {
@@ -433,9 +433,9 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
-			name = Debug;
+			name = Development;
 		};
-		DD0CC67F2D4B88E800DAC02D /* Release */ = {
+		DD0CC67F2D4B88E800DAC02D /* Production */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DD7E54DD2DB0F54F00A31DDD /* Production.xcconfig */;
 			buildSettings = {
@@ -490,9 +490,9 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = Production;
 		};
-		DD0CC6812D4B88E800DAC02D /* Debug */ = {
+		DD0CC6812D4B88E800DAC02D /* Development */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DD7E4A2A2DA5214D00A31DDD /* Development.xcconfig */;
 			buildSettings = {
@@ -520,24 +520,24 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = xyz.prism.PrismMessenger;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.prism.PrismMessenger.dev;
+				PRODUCT_NAME = "Prism Messenger Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Prism Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "PrismMessenger Development";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
-			name = Debug;
+			name = Development;
 		};
-		DD0CC6822D4B88E800DAC02D /* Release */ = {
+		DD0CC6822D4B88E800DAC02D /* Production */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DD7E54DD2DB0F54F00A31DDD /* Production.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = PrismMessenger/PrismMessenger.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"PrismMessenger/Preview Content\"";
@@ -559,16 +559,16 @@
 				);
 				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.prism.PrismMessenger;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "Prism Messenger";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Prism Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "PrismMessenger Production";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
-			name = Release;
+			name = Production;
 		};
-		DD0CC6842D4B88E800DAC02D /* Debug */ = {
+		DD0CC6842D4B88E800DAC02D /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -585,9 +585,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrismMessenger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PrismMessenger";
 			};
-			name = Debug;
+			name = Development;
 		};
-		DD0CC6852D4B88E800DAC02D /* Release */ = {
+		DD0CC6852D4B88E800DAC02D /* Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -604,9 +604,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrismMessenger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PrismMessenger";
 			};
-			name = Release;
+			name = Production;
 		};
-		DD0CC6872D4B88E800DAC02D /* Debug */ = {
+		DD0CC6872D4B88E800DAC02D /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -621,9 +621,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = PrismMessenger;
 			};
-			name = Debug;
+			name = Development;
 		};
-		DD0CC6882D4B88E800DAC02D /* Release */ = {
+		DD0CC6882D4B88E800DAC02D /* Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -638,9 +638,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = PrismMessenger;
 			};
-			name = Release;
+			name = Production;
 		};
-		DD508DFC2D8AB2FA00293B79 /* Debug */ = {
+		DD508DFC2D8AB2FA00293B79 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -656,9 +656,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrismMessenger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PrismMessenger";
 			};
-			name = Debug;
+			name = Development;
 		};
-		DD508DFD2D8AB2FA00293B79 /* Release */ = {
+		DD508DFD2D8AB2FA00293B79 /* Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -674,7 +674,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrismMessenger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PrismMessenger";
 			};
-			name = Release;
+			name = Production;
 		};
 /* End XCBuildConfiguration section */
 
@@ -682,47 +682,47 @@
 		DD0CC6572D4B88E600DAC02D /* Build configuration list for PBXProject "PrismMessenger" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD0CC67E2D4B88E800DAC02D /* Debug */,
-				DD0CC67F2D4B88E800DAC02D /* Release */,
+				DD0CC67E2D4B88E800DAC02D /* Development */,
+				DD0CC67F2D4B88E800DAC02D /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		DD0CC6802D4B88E800DAC02D /* Build configuration list for PBXNativeTarget "PrismMessenger" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD0CC6812D4B88E800DAC02D /* Debug */,
-				DD0CC6822D4B88E800DAC02D /* Release */,
+				DD0CC6812D4B88E800DAC02D /* Development */,
+				DD0CC6822D4B88E800DAC02D /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		DD0CC6832D4B88E800DAC02D /* Build configuration list for PBXNativeTarget "PrismMessengerTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD0CC6842D4B88E800DAC02D /* Debug */,
-				DD0CC6852D4B88E800DAC02D /* Release */,
+				DD0CC6842D4B88E800DAC02D /* Development */,
+				DD0CC6852D4B88E800DAC02D /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		DD0CC6862D4B88E800DAC02D /* Build configuration list for PBXNativeTarget "PrismMessengerUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD0CC6872D4B88E800DAC02D /* Debug */,
-				DD0CC6882D4B88E800DAC02D /* Release */,
+				DD0CC6872D4B88E800DAC02D /* Development */,
+				DD0CC6882D4B88E800DAC02D /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		DD508DFB2D8AB2FA00293B79 /* Build configuration list for PBXNativeTarget "PrismMessengerIntegrationTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD508DFC2D8AB2FA00293B79 /* Debug */,
-				DD508DFD2D8AB2FA00293B79 /* Release */,
+				DD508DFC2D8AB2FA00293B79 /* Development */,
+				DD508DFD2D8AB2FA00293B79 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 /* End XCConfigurationList section */
 


### PR DESCRIPTION
That way, developers can have multiple apps installed (e.g. TestFlight and local dev version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Renamed build configurations from "Debug"/"Release" to "Development"/"Production" across the app and test targets.
  - Updated app product name and bundle identifier for the development build to "Prism Messenger Dev."
  - Adjusted provisioning profiles and code signing identities to match the new configuration names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->